### PR TITLE
Allow platform(libv2ray) to override asset file location.

### DIFF
--- a/assets/path.go
+++ b/assets/path.go
@@ -1,0 +1,39 @@
+package assets
+
+import (
+	"os"
+	"path/filepath"
+)
+
+/*platformDefinedPath defines the asset path
+designted by execution platform*/
+var platformDefinedPath string
+
+/*GetEffectiveAssetsPath returns the path
+where asset files can be located.
+
+Currently, only platform can set such an lookup path,
+and a path defined by platform overrides default one.
+
+If no asset path have been defined, this function returns
+filepath.Dir(os.Executable(){0})
+*/
+func GetEffectiveAssetsPath() (string, error) {
+	if platformDefinedPath != "" {
+		return platformDefinedPath, nil
+	}
+	path, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(path), nil
+}
+
+/*SetPlatformDefinedPath set the path to lookup assets
+Only Developers in the Platform role should be able to
+set assets load path with this method as the path defined
+here is never checked.
+*/
+func SetPlatformDefinedPath(pdp string) {
+	platformDefinedPath = pdp
+}

--- a/tools/conf/router.go
+++ b/tools/conf/router.go
@@ -12,6 +12,7 @@ import (
 	"v2ray.com/core/app/router"
 	v2net "v2ray.com/core/common/net"
 	"v2ray.com/core/tools/geoip"
+	"v2ray.com/ext/assets"
 
 	"github.com/golang/protobuf/proto"
 )
@@ -104,11 +105,11 @@ func ParseIP(s string) (*router.CIDR, error) {
 }
 
 func loadGeoIP(country string) ([]*router.CIDR, error) {
-	path, err := os.Executable()
+	path, err := assets.GetEffectiveAssetsPath()
 	if err != nil {
 		return nil, err
 	}
-	geoipFile := filepath.Join(filepath.Dir(path), "geoip.dat")
+	geoipFile := filepath.Join(path, "geoip.dat")
 	geoipReader, err := os.Open(geoipFile)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Allow platform code(like libv2ray which is used by V2RayGo, Ac,Ng) to define a path where V2Ray ext can look up binary assets.

Without these necessary change, V2Ray will keep looking up assets from path that App has no write access or shouldn't modify. 