### PR TITLE
Fix id type mismatch error

### DIFF
--- a/tools/build/github.go
+++ b/tools/build/github.go
@@ -26,7 +26,7 @@ func newGithubClient(account *GithubAccount) (*github.Client, error) {
 	return github.NewClient(oauth2.NewClient(ctx, ts)), nil
 }
 
-func GithubCreateRelease(ctx context.Context, account *GithubAccount, tag string, pre bool) (int, error) {
+func GithubCreateRelease(ctx context.Context, account *GithubAccount, tag string, pre bool) (int64, error) {
 	client, err := newGithubClient(account)
 	if err != nil {
 		return 0, err
@@ -41,7 +41,7 @@ func GithubCreateRelease(ctx context.Context, account *GithubAccount, tag string
 	return release.GetID(), nil
 }
 
-func GithubUploadAsset(ctx context.Context, account *GithubAccount, id int, file string) error {
+func GithubUploadAsset(ctx context.Context, account *GithubAccount, id int64, file string) error {
 	fileReader, err := os.Open(file)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Why I open this pull request ? 
When I try go build  v2ray-core under `go version go1.9.3 darwin/amd64`   with   this command

```
go install v2ray.com/ext/tools/build/vbuild
```
I got  the following error

```
go install v2ray.com/ext/tools/build/vbuild
# v2ray.com/ext/tools/build
tools/build/github.go:41:22: cannot use release.GetID() (type int64) as type int in return argument
tools/build/github.go:55:78: cannot use id (type int) as type int64 in argument to client.Repositories.UploadReleaseAsset
```