### PR TITLE
support dragonfly bsd

### DIFF
--- a/tools/build/v2ray.go
+++ b/tools/build/v2ray.go
@@ -39,6 +39,7 @@ func getReleases() map[releaseID][]build.Target {
 			genReleaseID(build.OpenBSD, build.X86):    append(genRegularTarget(build.OpenBSD, build.X86)),
 			genReleaseID(build.FreeBSD, build.Amd64):  append(genRegularTarget(build.FreeBSD, build.Amd64)),
 			genReleaseID(build.FreeBSD, build.X86):    append(genRegularTarget(build.FreeBSD, build.X86)),
+			genReleaseID(build.DragonflyBSD, build.Amd64):    append(genRegularTarget(build.DragonflyBSD, build.Amd64)),
 		}
 	}
 	return releases


### PR DESCRIPTION
add build target, v3.26 release dragonfly target is empty