### PR TITLE
Optimize dockerfile and use google distroless as runtime image

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -20,6 +20,7 @@ RUN V2RAY_FILE=v2ray-${OS}-${ARCH}.zip \
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # Note: Use gcr.azk8s.cn as repo-mirror if gcr.io is blocked by China GFW.
 FROM gcr.io/distroless/static:latest
+LABEL maintainer "Darian Raymond <admin@v2ray.com>"
 WORKDIR /etc/v2ray
 COPY --from=downloader /etc/v2ray .
 COPY config.json /etc/v2ray/config.json

--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -1,27 +1,27 @@
-FROM ubuntu:latest as builder
+FROM alpine:3.11 AS downloader
 
-RUN apt-get update
-RUN apt-get install curl -y
-RUN curl -L -o /tmp/go.sh https://install.direct/go.sh
-RUN chmod +x /tmp/go.sh
-RUN /tmp/go.sh
+RUN apk add -U --no-cache curl
 
-FROM alpine:latest
+WORKDIR /etc/v2ray
+# Configurable arguments defined at build time. User can override them by docker build --build-arg ARG_NAME=ARG_VALUE
+# Default OS type = linux
+ARG OS=linux
+# Default architecture = 64
+ARG ARCH=64
+# Download and unpack latest release from official github release
+RUN V2RAY_FILE=v2ray-${OS}-${ARCH}.zip \
+    VERSION=$(curl -s https://github.com/v2ray/v2ray-core/releases/latest |grep -oE '\d\.\d+\.\d+') \
+    && echo "Got latest version = ${VERSION}, file = ${V2RAY_FILE}" \
+    && curl -Lo $V2RAY_FILE https://github.com/v2ray/v2ray-core/releases/download/v${VERSION}/$V2RAY_FILE \
+    && unzip $V2RAY_FILE \
+    && rm $V2RAY_FILE
 
-LABEL maintainer "Darian Raymond <admin@v2ray.com>"
-
-COPY --from=builder /usr/bin/v2ray/v2ray /usr/bin/v2ray/
-COPY --from=builder /usr/bin/v2ray/v2ctl /usr/bin/v2ray/
-COPY --from=builder /usr/bin/v2ray/geoip.dat /usr/bin/v2ray/
-COPY --from=builder /usr/bin/v2ray/geosite.dat /usr/bin/v2ray/
+# Use distroless as minimal base image to package the executable binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+# Note: Use gcr.azk8s.cn as repo-mirror if gcr.io is blocked by China GFW.
+FROM gcr.io/distroless/static:latest
+WORKDIR /etc/v2ray
+COPY --from=downloader /etc/v2ray .
 COPY config.json /etc/v2ray/config.json
-
-RUN set -ex && \
-    apk --no-cache add ca-certificates && \
-    mkdir /var/log/v2ray/ &&\
-    chmod +x /usr/bin/v2ray/v2ctl && \
-    chmod +x /usr/bin/v2ray/v2ray
-
-ENV PATH /usr/bin/v2ray:$PATH
-
-CMD ["v2ray", "-config=/etc/v2ray/config.json"]
+ENTRYPOINT ["/etc/v2ray/v2ray"]
+CMD ["-config=/etc/v2ray/config.json"]

--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -24,5 +24,5 @@ LABEL maintainer "Darian Raymond <admin@v2ray.com>"
 WORKDIR /etc/v2ray
 COPY --from=downloader /etc/v2ray .
 COPY config.json /etc/v2ray/config.json
-ENTRYPOINT ["/etc/v2ray/v2ray"]
-CMD ["-config=/etc/v2ray/config.json"]
+ENV PATH /etc/v2ray:$PATH
+CMD ["v2ray", "-config=/etc/v2ray/config.json"]

--- a/docker/official/config.json
+++ b/docker/official/config.json
@@ -1,7 +1,7 @@
 {
   "log" : {
-    "access": "/var/log/v2ray/access.log",
-    "error": "/var/log/v2ray/error.log",
+    "access": "/dev/stdout",
+    "error": "/dev/stderr",
     "loglevel": "warning"
   },
   "inbounds": [{


### PR DESCRIPTION
## What does this PR do

1. Download latest release from v2ray-core github release directly without install various helper packages. We use `alpine` as a builder image to speedup build process. And the OS and architecture type can be configured at built time via `--build-arg`

2. Use  `gcr.io/distroless/static` as runtime base image. This is a perfect base image for static built executable binaries. For more details and its advantages, please see [GoogleContainerTools/distroless](https://github.com/GoogleContainerTools/distroless)

3. The default `config.json` logs to `stdout` and `stderr` by default. Because this is a container, it should output to stdout instead of a file inside the container.

4. The final image size (Compacted size, shown on docker hub) is 12MB, which is 50% smaller than the current `v2ray/official` image (24MB).